### PR TITLE
chore(Rails 7): Allow Rails < 8

### DIFF
--- a/codemirror-rails.gemspec
+++ b/codemirror-rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('{doc,lib,vendor}/**/*') + %w[LICENSE README.md]
 
-  s.add_runtime_dependency 'railties', '>= 3.0', '< 7.0'
+  s.add_runtime_dependency 'railties', '>= 3.0', '< 8.0'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'rails'

--- a/lib/codemirror/rails/version.rb
+++ b/lib/codemirror/rails/version.rb
@@ -1,6 +1,6 @@
 module Codemirror
   module Rails
-    VERSION = '5.16.0'
-    CODEMIRROR_VERSION = '5.16.0'
+    VERSION = '5.17.0'.freeze
+    CODEMIRROR_VERSION = '5.17.0'.freeze
   end
 end


### PR DESCRIPTION
## Why this was needed
Services is finally getting on Rails 7. As the only consumer of this Gem it's prob safe to allow it.

## How I did it
- Updated the gemspec to allow < Rails 8
- Updated version